### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/hql-builder/pom.xml
+++ b/hql-builder/pom.xml
@@ -57,7 +57,7 @@
 		<version.commons-io>2.4</version.commons-io><!-- stale, keep up to date -->
 		<version.commons-lang>2.6</version.commons-lang><!-- stale -->
 		<version.commons-lang3>3.3.1</version.commons-lang3><!-- recent version, keep up to date -->
-		<version.commons-collections>3.2.1</version.commons-collections><!-- stale -->
+		<version.commons-collections>3.2.2</version.commons-collections><!-- stale -->
 		<version.commons-collections4>4.0</version.commons-collections4><!-- recent version, keep up to date -->
 		<version.commons-beanutils>1.9.2</version.commons-beanutils><!-- recent version, keep up to date -->
 		<version.javassist>3.19.0-GA</version.javassist><!-- Java 1.8 ready -->


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/